### PR TITLE
Implement md to html filter template

### DIFF
--- a/blog/templates/article.html
+++ b/blog/templates/article.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load md_to_html %}
 
 {% block title %}
     <title>{{ article.title }}</title>
@@ -14,6 +15,6 @@
         </h3>
     </header>
     <article class="article-content">
-        {{ article.content }}
+        {{ article.content|md_to_html }}
     </article>
 {% endblock %}

--- a/blog/templatetags/md_to_html.py
+++ b/blog/templatetags/md_to_html.py
@@ -1,0 +1,12 @@
+import markdown
+from django import template
+from django.utils.html import mark_safe
+
+register = template.Library()
+
+
+@register.filter
+def md_to_html(value):
+    md_converter = markdown.Markdown()
+    converted_content = md_converter.convert(value)
+    return mark_safe(converted_content)

--- a/blog/tests/e2e/base.py
+++ b/blog/tests/e2e/base.py
@@ -34,7 +34,7 @@ class TestBase(LiveServerTestCase):
         self.browser.close()
     
     def __init_browser(self) -> webdriver.Chrome:
-        """Initilize webdriver object for Chrome.
+        """Initialize webdriver object for Chrome.
 
         Returns
         -------
@@ -42,6 +42,7 @@ class TestBase(LiveServerTestCase):
             Instance of Chrome webdriver.
         """
         chrome_options = Options()
+        chrome_options.add_argument("--disable-search-engine-choice-screen")
         chrome_options.add_argument("--headless")
         return webdriver.Chrome(options=chrome_options)
 

--- a/blog/tests/e2e/test_articles.py
+++ b/blog/tests/e2e/test_articles.py
@@ -53,3 +53,37 @@ class TestArticles(TestBase):
 
         main_page = MainPage(self.browser).navigate()
         self.assertFalse(main_page.is_article_visible(article.title))
+
+    def test_can_handle_markdown_format(self):
+        """Test that it's possible to handle content written in Markdown"""
+        md_article = {
+            "title": "Test Article",
+            "publish_date": "2024-10-11",
+            "content": """
+                # Some good title
+
+                ## Part One
+                This is part one
+
+                ## Part Two
+                This is part two
+            """
+        }
+        admin_login_page = AdminLoginPage(self.browser).navigate()
+        admin_page = admin_login_page.login(self.admin["username"], self.admin["password"])
+        
+        admin_articles_page = admin_page.navigate_to_articles()
+        admin_articles_page.add_new_article(md_article)
+
+        article_page = ArticlePage(self.browser).navigate(self.article["title"])
+        content = article_page.get_content()
+        expected = """
+            Some good title
+
+            Part One
+            This is part one
+
+            Part Two
+            This is part two
+        """
+        self.assertEqual(content, expected)

--- a/blog/tests/e2e/test_articles.py
+++ b/blog/tests/e2e/test_articles.py
@@ -59,15 +59,7 @@ class TestArticles(TestBase):
         md_article = {
             "title": "Test Article",
             "publish_date": "2024-10-11",
-            "content": """
-                # Some good title
-
-                ## Part One
-                This is part one
-
-                ## Part Two
-                This is part two
-            """
+            "content": """# Some good title\n## Part One\nThis is part one"""
         }
         admin_login_page = AdminLoginPage(self.browser).navigate()
         admin_page = admin_login_page.login(self.admin["username"], self.admin["password"])
@@ -77,13 +69,6 @@ class TestArticles(TestBase):
 
         article_page = ArticlePage(self.browser).navigate(self.article["title"])
         content = article_page.get_content()
-        expected = """
-            Some good title
 
-            Part One
-            This is part one
-
-            Part Two
-            This is part two
-        """
+        expected = """Some good title\nPart One\nThis is part one"""
         self.assertEqual(content, expected)

--- a/blog/tests/integration/test_article_page_view.py
+++ b/blog/tests/integration/test_article_page_view.py
@@ -21,3 +21,17 @@ class TestArticlePageView(TestCase):
         """
         response = self.client.get(self.article_url)
         self.assertEqual(self.article, response.context["article"])
+
+    def test_article_page_handle_markdown_content(self):
+        """Tests that article page properly converts Markdown format."""
+        md_article = Article.objects.create(
+            title="Test Article MD",
+            content="""# Test title\nTest content"""
+        )
+
+        md_article_url = md_article.get_absolute_url()
+        response = self.client.get(md_article_url)
+        expected = """<h1>Test title</h1>\n<p>Test content</p>"""
+        print(response.content)
+
+        self.assertInHTML(expected, str(response.content))

--- a/blog/tests/integration/test_article_page_view.py
+++ b/blog/tests/integration/test_article_page_view.py
@@ -32,6 +32,5 @@ class TestArticlePageView(TestCase):
         md_article_url = md_article.get_absolute_url()
         response = self.client.get(md_article_url)
         expected = """<h1>Test title</h1>\n<p>Test content</p>"""
-        print(response.content)
 
         self.assertInHTML(expected, str(response.content))


### PR DESCRIPTION
This issue was opened to implement logic that will handle articles written in Markdown format and convert it into HTML, so will be displayed on the website.